### PR TITLE
mod_storage_sql: fix stores and store_exists

### DIFF
--- a/plugins/mod_storage_sql.lua
+++ b/plugins/mod_storage_sql.lua
@@ -293,9 +293,7 @@ function driver:open(store, typ)
 end
 
 function driver:stores(username, type, pattern)
-	local sql = "SELECT DISTINCT `store` FROM `metronome` WHERE `host`=? AND `user`"..(username == true and "!=?" or "=?").." AND `type`=? AND `store` LIKE ?";
-
-	type = type or "keyval";
+	local sql = "SELECT DISTINCT `store` FROM `metronome` WHERE `host`=? AND `user`"..(username == true and "!=?" or "=?").." AND `store` LIKE ?";
 
 	if username == true or not username then
 		username = "";
@@ -307,7 +305,7 @@ function driver:stores(username, type, pattern)
 		pattern = "%";
 	end
 
-	local stmt, err = dosql(sql, host, username, type, pattern);
+	local stmt, err = dosql(sql, host, username, pattern);
 	if not stmt then
 		return rollback(nil, err);
 	end
@@ -319,18 +317,16 @@ function driver:stores(username, type, pattern)
 end
 
 function driver:store_exists(username, datastore, type)
-	local sql = "SELECT DISTINCT `store` FROM `metronome` WHERE `host`=? and `user`"..(username == true and "!=?" or "=?").." AND `store`=? AND `type` =?";
-
-	type = type or "keyval";
+	local sql = "SELECT DISTINCT `store` FROM `metronome` WHERE `host`=? and `user`"..(username == true and "!=?" or "=?").." AND `store`=?";
 
 	if username == true or not username then username = ""; end
 
-	local stmt, err = dosql(sql, host, username, datastore, type);
+	local stmt, err = dosql(sql, host, username, datastore);
 	if not stmt then
 		return rollback(nil, err);
 	end
 	local count = 0;
-	for i, row in ipairs(stmt:rows()) do
+	for row in stmt:rows() do
 		count = count + 1;
 	end
 	if count > 0 then 


### PR DESCRIPTION
When I wrote this, I completely forgot that the SQL storage uses type to specify the type of item stored (json, number, string, boolean, etc).

Also, stmt:rows() returns a function, not a table, I fixed that as well.
