### PR TITLE
Fixing typo causing exception in mod_muc_log

### DIFF
--- a/plugins/mod_muc_log.lua
+++ b/plugins/mod_muc_log.lua
@@ -91,7 +91,7 @@ end
 
 function clear_logs(event) -- clear logs from disk
 	local node = jid_section(event.room.jid, "node");
-	for store in datamanager_stores(node, mod_host, "keyval", datastore) do
+	for store in data_stores(node, mod_host, "keyval", datastore) do
 		data_store(node, mod_host, store, nil);
 	end
 end


### PR DESCRIPTION
The typo was causing the following exception:

```
Jan 01 15:32:10 http.server     error   Traceback[http]: /usr/local/lib/metronome/modules/mod_muc_log.lua:94: attempt to call global 'datamanager_stores' (a nil value): stack traceback:
        /usr/local/lib/metronome/net/http/server.lua:99: in function </usr/local/lib/metronome/net/http/server.lua:99>
        [C]: in function 'parse'
        /usr/local/lib/metronome/util/xmppstream.lua:200: in function 'feed'
        /usr/local/lib/metronome/modules/mod_bosh.lua:135: in function '?'
        /usr/local/lib/metronome/util/events.lua:67: in function 'fire_event'
        /usr/local/lib/metronome/net/http/server.lua:208: in function </usr/local/lib/metronome/net/http/server.lua:161>
        (tail call): ?
        [C]: in function 'xpcall'
        /usr/local/lib/metronome/net/http/server.lua:114: in function 'process_next'
        /usr/local/lib/metronome/net/http/server.lua:128: in function 'success_cb'
        /usr/local/lib/metronome/net/http/parser.lua:141: in function 'feed'
        /usr/local/lib/metronome/net/http/server.lua:150: in function 'onincoming'
        /usr/local/lib/metronome/net/server_event.lua:611: in function </usr/local/lib/metronome/net/server_event.lua:561>
        [C]: in function 'loop'
        /usr/local/lib/metronome/net/server_event.lua:767: in function </usr/local/lib/metronome/net/server_event.lua:766>
        [C]: in function 'xpcall'
        /usr/local/lib/metronome/../../bin/metronome:324: in function 'loop'
        /usr/local/lib/metronome/../../bin/metronome:388: in main chunk
        [C]: ?
```