### PR TITLE
mod register: Add subnet matching for the blacklist and whitelist

### DIFF
--- a/plugins/mod_register.lua
+++ b/plugins/mod_register.lua
@@ -227,6 +227,10 @@ module:hook("stanza/iq/jabber:iq:register:query", function(event)
 					-- Check that the user is not blacklisted or registering too often
 					if not session.ip then
 						module:log("debug", "User's IP not known; can't apply blacklist/whitelist");
+						if whitelist_only then
+							session.send(st.error_reply(stanza, "cancel", "not-acceptable", "You are not allowed to register an account."));
+							return true;
+						end
 					elseif subnets_match_ip(blacklisted_ips, session.ip) or (whitelist_only and not subnets_match_ip(whitelisted_ips, session.ip)) then
 						session.send(st.error_reply(stanza, "cancel", "not-acceptable", "You are not allowed to register an account."));
 						return true;

--- a/plugins/mod_register.lua
+++ b/plugins/mod_register.lua
@@ -18,6 +18,8 @@ local usermanager_delete_user = require "core.usermanager".delete_user;
 local os_time = os.time;
 local nodeprep = require "util.encodings".stringprep.nodeprep;
 local jid_bare = require "util.jid".bare;
+local new_ip = require "util.ip".new_ip;
+local match_subnet = require "util.ip".match_subnet;
 
 local compat = module:get_option_boolean("registration_compat", true);
 local allow_registration = module:get_option_boolean("allow_registration", false);
@@ -168,14 +170,40 @@ local function parse_response(query)
 	end
 end
 
+local function parse_subnet(subnet)
+	local ip, mask = subnet:match("^([%x.:]*)/?(%d*)$");
+	ip = ip and new_ip(ip) or nil;
+	return ip and { addr = ip, mask = tonumber(mask) } or nil;
+end
+
+local function parse_subnets(lst)
+	local subnets = {};
+	for _, s in ipairs(lst) do
+		s = parse_subnet(s);
+		if s then
+			table.insert(subnets, s);
+		end
+	end
+	return subnets;
+end
+
+local function subnets_match_ip(subnets, ip)
+	ip = new_ip(ip);
+	if ip then
+		for _, s in ipairs(subnets) do
+			if match_subnet(ip, s.addr, s.mask) then
+				return true;
+			end
+		end
+	end
+	return false;
+end
+
 local recent_ips = {};
 local min_seconds_between_registrations = module:get_option("min_seconds_between_registrations");
 local whitelist_only = module:get_option("whitelist_registration_only");
-local whitelisted_ips = module:get_option("registration_whitelist") or { "127.0.0.1" };
-local blacklisted_ips = module:get_option("registration_blacklist") or {};
-
-for _, ip in ipairs(whitelisted_ips) do whitelisted_ips[ip] = true; end
-for _, ip in ipairs(blacklisted_ips) do blacklisted_ips[ip] = true; end
+local whitelisted_ips = parse_subnets(module:get_option("registration_whitelist") or { "127.0.0.1" });
+local blacklisted_ips = parse_subnets(module:get_option("registration_blacklist") or {});
 
 module:hook("stanza/iq/jabber:iq:register:query", function(event)
 	local session, stanza = event.origin, event.stanza;
@@ -199,10 +227,10 @@ module:hook("stanza/iq/jabber:iq:register:query", function(event)
 					-- Check that the user is not blacklisted or registering too often
 					if not session.ip then
 						module:log("debug", "User's IP not known; can't apply blacklist/whitelist");
-					elseif blacklisted_ips[session.ip] or (whitelist_only and not whitelisted_ips[session.ip]) then
+					elseif subnets_match_ip(blacklisted_ips, session.ip) or (whitelist_only and not subnets_match_ip(whitelisted_ips, session.ip)) then
 						session.send(st.error_reply(stanza, "cancel", "not-acceptable", "You are not allowed to register an account."));
 						return true;
-					elseif min_seconds_between_registrations and not whitelisted_ips[session.ip] then
+					elseif min_seconds_between_registrations and not subnets_match_ip(whitelisted_ips, session.ip) then
 						if not recent_ips[session.ip] then
 							recent_ips[session.ip] = { time = os_time(), count = 1 };
 						else

--- a/util/ip.lua
+++ b/util/ip.lua
@@ -14,7 +14,10 @@ local ip_mt = { __index = function (ip, key) return (ip_methods[key])(ip); end,
 local hex2bits = { ["0"] = "0000", ["1"] = "0001", ["2"] = "0010", ["3"] = "0011", ["4"] = "0100", ["5"] = "0101", ["6"] = "0110", ["7"] = "0111", ["8"] = "1000", ["9"] = "1001", ["A"] = "1010", ["B"] = "1011", ["C"] = "1100", ["D"] = "1101", ["E"] = "1110", ["F"] = "1111" };
 
 local function new_ip(ipStr, proto)
-	if proto ~= "IPv4" and proto ~= "IPv6" then
+	-- If no protocol was given try to autodetect
+	if not proto then
+		proto = ipStr:match(":") and "IPv6" or "IPv4";
+	elseif proto ~= "IPv4" and proto ~= "IPv6" then
 		return nil, "invalid protocol";
 	end
 	if proto == "IPv6" and ipStr:find('.', 1, true) then

--- a/util/ip.lua
+++ b/util/ip.lua
@@ -72,6 +72,15 @@ local function match_prefix(ipA, ipB)
 	return len < 64 and len or 64;
 end
 
+local function match_subnet(ipA, subnet, len)
+	if len and subnet.proto == "IPv4" then
+		len = len + 128 - 32;
+	end
+	ipA, subnet = toBits(ipA), toBits(subnet);
+	len = (len == nil or len > 128) and 128 or len;
+	return ipA:sub(1, len) == subnet:sub(1, len);
+end
+
 local function v4scope(ip)
 	local fields = {};
 	ip:gsub("([^.]*).?", function (c) fields[#fields + 1] = tonumber(c) end);
@@ -288,5 +297,6 @@ return {
 	new_ip = new_ip,
 	compare_destination = compare_destination,
 	compare_source = compare_source,
-	match_prefix = match_prefix
+	match_prefix = match_prefix,
+	match_subnet = match_subnet
 };


### PR DESCRIPTION
Improve the blacklist and whitelist by allowing to give subnets instead of single IPs. This is useful to configure metronome to only accept registrations from the local network.

Also included in this pull request is a patch to fix the whitelist only mode to reject sessions that don't have an IP. I don't know if it can really happen in practice but that seemed like the right thing to do if only known peers should be accepted.