### PR TITLE
scripts.logrotate: update logrotate script to avoid error.

### DIFF
--- a/scripts/logrotate
+++ b/scripts/logrotate
@@ -2,6 +2,7 @@
 	daily
 	rotate 14
 	compress
+	delaycompress
 	create 640 metronome adm
 	postrotate
 		/usr/bin/metronomectl reload > /dev/null


### PR DESCRIPTION
Avoid this error:
/etc/cron.daily/logrotate:
gzip: stdin: file size changed while zipping