### PR TITLE
util.hmac: fix HMAC for SHA384 and SHA512

### DIFF
--- a/util/hmac.lua
+++ b/util/hmac.lua
@@ -68,11 +68,11 @@ function sha256(key, message, hex)
 end
 
 function sha384(key, message, hex)
-	return hmac(key, message, hashes.sha384, 64, hex)
+	return hmac(key, message, hashes.sha384, 128, hex)
 end
 
 function sha512(key, message, hex)
-	return hmac(key, message, hashes.sha512, 64, hex)
+	return hmac(key, message, hashes.sha512, 128, hex)
 end
 
 return _M


### PR DESCRIPTION
According to RFC4868, blocksize for SHA256 is 512 bits (64 bytes), but
for SHA384 and SHA512 it is 1024 bits (128 bytes).

Also, RFC4231 provides test vectors which fail when blocksize for SHA512
is 64 bytes.

qxmpp-project/qxmpp#177 mentions that the client fails to authenticate
with SCRAM-SHA-512. Libstrophe library fails to authenticate as well.
However, authentication is successful when libstrophe uses blocksize
64 for HMAC-SHA-512.