### PR TITLE
Change openssl.cnf to use correct OIDs for newer openssl versions

### DIFF
--- a/certs/openssl.cnf
+++ b/certs/openssl.cnf
@@ -1,13 +1,3 @@
-oid_section = new_oids
-
-[ new_oids ]
-
-# RFC 3920 section 5.1.1 defines this OID
-xmppAddr = 1.3.6.1.5.5.7.8.5
-
-# RFC 4985 defines this OID
-SRVName  = 1.3.6.1.5.5.7.8.7
-
 [ req ]
 
 default_bits       = 4096
@@ -43,10 +33,10 @@ subjectAltName   = @subject_alternative_name
 # See http://tools.ietf.org/html/draft-ietf-xmpp-3920bis#section-13.7.1.2 for more info.
 
 DNS.0       =                                           example.com
-otherName.0 =                 xmppAddr;FORMAT:UTF8,UTF8:example.com
+otherName.0 =                 XmppAddr;FORMAT:UTF8,UTF8:example.com
 otherName.1 =            SRVName;IA5STRING:_xmpp-client.example.com
 otherName.2 =            SRVName;IA5STRING:_xmpp-server.example.com
 
 DNS.1       =                                conference.example.com
-otherName.3 =      xmppAddr;FORMAT:UTF8,UTF8:conference.example.com
+otherName.3 =      XmppAddr;FORMAT:UTF8,UTF8:conference.example.com
 otherName.4 = SRVName;IA5STRING:_xmpp-server.conference.example.com


### PR DESCRIPTION
Fixes maranda/metronome/issues/552 (for me; on Debian 12 (Bookworm))