### PR TITLE
fix jabber:iq:last seconds format

### DIFF
--- a/plugins/mod_lastactivity.lua
+++ b/plugins/mod_lastactivity.lua
@@ -37,7 +37,7 @@ module:hook("iq/bare/jabber:iq:last:query", function(event)
 		if not stanza.attr.to or is_contact_subscribed(username, module_host, jid_bare(stanza.attr.from)) then
 			local seconds, text, data = "0", "", lastactivity:get(username);
 			if data then
-				seconds = tostring(os_difftime(os_time(), data.time));
+				seconds = string.format("%d", os_difftime(os_time(), data.time));
 				text = data.status;
 			end
 			origin.send(st.reply(stanza):tag("query", {xmlns = "jabber:iq:last", seconds = seconds}):text(text));

--- a/plugins/mod_uptime.lua
+++ b/plugins/mod_uptime.lua
@@ -18,7 +18,8 @@ module:add_feature("jabber:iq:last");
 module:hook("iq/host/jabber:iq:last:query", function(event)
 	local origin, stanza = event.origin, event.stanza;
 	if stanza.attr.type == "get" then
-		origin.send(st.reply(stanza):tag("query", {xmlns = "jabber:iq:last", seconds = tostring(os.difftime(os.time(), start_time))}));
+		seconds = string.format("%d", os.difftime(os.time(), start_time));
+		origin.send(st.reply(stanza):tag("query", {xmlns = "jabber:iq:last", seconds = seconds}));
 		return true;
 	end
 end);


### PR DESCRIPTION
The seconds='32335.0' is a float while XMPP clients expect it to be a long integer
```xml
<iq to='juliet@capulet.org' from='romeo@lightwitch.org' type='result' id='Y9MR1-138'>
<query xmlns='jabber:iq:last' seconds='32335.0'>
    Logged out
</query>
</iq>
```

This caused the exception in Smack library:
```
java.lang.NumberFormatException: For input string: "32335.0"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Long.parseLong(Long.java:836)
	at org.jivesoftware.smackx.iqlast.packet.LastActivity$Provider.parse(LastActivity.java:111)
```

The issue was fixed in the Prosody and I made a similar fix.